### PR TITLE
Add getter for record fields

### DIFF
--- a/r_get_record.go
+++ b/r_get_record.go
@@ -23,6 +23,11 @@ type Record struct {
 	Attachments  []*RecordAttachment `json:"attachments"`
 }
 
+// GetHeaderField returns either the value of the given header field or an empty string if the field does not exist.
+func (rec *Record) GetHeaderField(name string) string {
+	return rec.RecordFields[name]
+}
+
 type RecordAttachment struct {
 	Body            string    `json:"body"`
 	Name            string    `json:"name"`


### PR DESCRIPTION
Client users should use this getter instead of manually using the struct field. This ensures future changes to the struct are possible without breaking a lot of user code.