### PR TITLE
Add 'eastest' pkg with reusable test helpers

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"testing"
 
 	"github.com/DEXPRO-Solutions-GmbH/easclient"
 	"github.com/joho/godotenv"
@@ -34,10 +33,4 @@ func init() {
 	serverClient.SetHostURL(fmt.Sprintf("http://%s/eas/archives", os.Getenv("EAS_HOST")))
 	serverClient.SetBasicAuth(os.Getenv("EAS_USER"), os.Getenv("EAS_PASSWORD"))
 	DefaultServerClient = easclient.NewServerClient(serverClient)
-}
-
-func testPrelude(t *testing.T) {
-	if os.Getenv("GITHUB_ACTION") != "" {
-		t.Skip("Tests can't currently be run in the GitHub Action environment. We will first have to make it possible to run the EAS or a mocked variant in CI")
-	}
 }

--- a/eastest/clients.go
+++ b/eastest/clients.go
@@ -16,6 +16,7 @@ var (
 	defaultServerOnce   sync.Once
 )
 
+// DefaultClient returns an a client based on ENV variables: EAS_HOST, EAS_STORE, EAS_USER, EAS_PASSWORD
 func DefaultClient() *easclient.StoreClient {
 	defaultClientOnce.Do(func() {
 		client := resty.New()
@@ -27,6 +28,7 @@ func DefaultClient() *easclient.StoreClient {
 	return defaultClient
 }
 
+// DefaultServerClient returns an a client based on ENV variables: EAS_HOST, EAS_USER, EAS_PASSWORD
 func DefaultServerClient() *easclient.ServerClient {
 	defaultServerOnce.Do(func() {
 		serverClient := resty.New()

--- a/eastest/clients.go
+++ b/eastest/clients.go
@@ -1,13 +1,11 @@
 package eastest
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"sync"
 
 	"github.com/DEXPRO-Solutions-GmbH/easclient"
-	"github.com/joho/godotenv"
 	"gopkg.in/resty.v1"
 )
 
@@ -38,14 +36,4 @@ func DefaultServerClient() *easclient.ServerClient {
 	})
 
 	return defaultServerClient
-}
-
-// init is run before any tests are executed.
-// it loads the environment variables from .env and creates
-// a default client for all tests to use.
-func init() {
-	err := godotenv.Load(".env")
-	if errors.Is(err, os.ErrNotExist) {
-		return
-	}
 }

--- a/eastest/clients.go
+++ b/eastest/clients.go
@@ -1,4 +1,4 @@
-package easclient_test
+package eastest
 
 import (
 	"errors"

--- a/eastest/package.go
+++ b/eastest/package.go
@@ -1,0 +1,2 @@
+// Package eastest contains test helpers for testing with the EAS.
+package eastest

--- a/eastest/skip.go
+++ b/eastest/skip.go
@@ -1,0 +1,13 @@
+package eastest
+
+import (
+	"os"
+	"testing"
+)
+
+// SkipInCI is used to skip tests if they can not be executed in the current environment.
+func SkipInCI(t *testing.T) {
+	if os.Getenv("GITHUB_ACTION") != "" {
+		t.Skip("Tests can't currently be run in the GitHub Action environment. We will first have to make it possible to run the EAS or a mocked variant in CI")
+	}
+}

--- a/internal/test.go
+++ b/internal/test.go
@@ -1,0 +1,22 @@
+package internal
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/joho/godotenv"
+)
+
+// TestPrelude is used by tests of this library to ensure that they behave as expected in the context
+// of our environments.
+func TestPrelude(t *testing.T) {
+	// Having this function be called ensures that the init() function is called.
+}
+
+func init() {
+	err := godotenv.Load(".env")
+	if errors.Is(err, os.ErrNotExist) {
+		return
+	}
+}

--- a/r_get_record_attachment_test.go
+++ b/r_get_record_attachment_test.go
@@ -20,7 +20,7 @@ func TestStoreClient_GetRecordAttachment(t *testing.T) {
 
 	buffer := new(bytes.Buffer)
 
-	record, err := eastest.DefaultClient.GetRecordAttachment(
+	record, err := eastest.DefaultClient().GetRecordAttachment(
 		ctx,
 		buffer,
 		uuid.MustParse("a65efcf9-8c74-4b84-8106-233c1c64a07c"),

--- a/r_get_record_attachment_test.go
+++ b/r_get_record_attachment_test.go
@@ -20,7 +20,7 @@ func TestStoreClient_GetRecordAttachment(t *testing.T) {
 
 	buffer := new(bytes.Buffer)
 
-	record, err := DefaultClient.GetRecordAttachment(
+	record, err := eastest.DefaultClient.GetRecordAttachment(
 		ctx,
 		buffer,
 		uuid.MustParse("a65efcf9-8c74-4b84-8106-233c1c64a07c"),

--- a/r_get_record_attachment_test.go
+++ b/r_get_record_attachment_test.go
@@ -6,12 +6,13 @@ import (
 	"testing"
 
 	"github.com/DEXPRO-Solutions-GmbH/easclient"
+	"github.com/DEXPRO-Solutions-GmbH/easclient/eastest"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
 func TestStoreClient_GetRecordAttachment(t *testing.T) {
-	testPrelude(t)
+	eastest.SkipInCI(t)
 
 	ctx := context.Background()
 	user := easclient.NewUserClaims("test@dexpro.de")

--- a/r_get_record_attachment_test.go
+++ b/r_get_record_attachment_test.go
@@ -7,11 +7,13 @@ import (
 
 	"github.com/DEXPRO-Solutions-GmbH/easclient"
 	"github.com/DEXPRO-Solutions-GmbH/easclient/eastest"
+	"github.com/DEXPRO-Solutions-GmbH/easclient/internal"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
 func TestStoreClient_GetRecordAttachment(t *testing.T) {
+	internal.TestPrelude(t)
 	eastest.SkipInCI(t)
 
 	ctx := context.Background()

--- a/r_get_record_test.go
+++ b/r_get_record_test.go
@@ -6,11 +6,13 @@ import (
 
 	"github.com/DEXPRO-Solutions-GmbH/easclient"
 	"github.com/DEXPRO-Solutions-GmbH/easclient/eastest"
+	"github.com/DEXPRO-Solutions-GmbH/easclient/internal"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
 func TestStoreClient_GetRecord(t *testing.T) {
+	internal.TestPrelude(t)
 	eastest.SkipInCI(t)
 
 	ctx := context.Background()

--- a/r_get_record_test.go
+++ b/r_get_record_test.go
@@ -5,12 +5,13 @@ import (
 	"testing"
 
 	"github.com/DEXPRO-Solutions-GmbH/easclient"
+	"github.com/DEXPRO-Solutions-GmbH/easclient/eastest"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
 )
 
 func TestStoreClient_GetRecord(t *testing.T) {
-	testPrelude(t)
+	eastest.SkipInCI(t)
 
 	ctx := context.Background()
 	user := easclient.NewUserClaims("test@dexpro.de")

--- a/r_get_record_test.go
+++ b/r_get_record_test.go
@@ -17,7 +17,7 @@ func TestStoreClient_GetRecord(t *testing.T) {
 	user := easclient.NewUserClaims("test@dexpro.de")
 	ctx = user.SetOnContext(ctx)
 
-	record, err := eastest.DefaultClient.GetRecord(ctx, uuid.MustParse("990ac5bf-1df5-45b8-82ca-41120621f826"))
+	record, err := eastest.DefaultClient().GetRecord(ctx, uuid.MustParse("990ac5bf-1df5-45b8-82ca-41120621f826"))
 	require.NoError(t, err)
 	require.NotNil(t, record)
 }

--- a/r_get_record_test.go
+++ b/r_get_record_test.go
@@ -17,7 +17,7 @@ func TestStoreClient_GetRecord(t *testing.T) {
 	user := easclient.NewUserClaims("test@dexpro.de")
 	ctx = user.SetOnContext(ctx)
 
-	record, err := DefaultClient.GetRecord(ctx, uuid.MustParse("990ac5bf-1df5-45b8-82ca-41120621f826"))
+	record, err := eastest.DefaultClient.GetRecord(ctx, uuid.MustParse("990ac5bf-1df5-45b8-82ca-41120621f826"))
 	require.NoError(t, err)
 	require.NotNil(t, record)
 }

--- a/r_get_store_status_test.go
+++ b/r_get_store_status_test.go
@@ -16,7 +16,7 @@ func TestStoreClient_GetStoreStatus(t *testing.T) {
 	user := easclient.NewUserClaims("test@dexpro.de")
 	ctx = user.SetOnContext(ctx)
 
-	status, err := eastest.DefaultClient.GetStoreStatus(ctx)
+	status, err := eastest.DefaultClient().GetStoreStatus(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, status)
 }

--- a/r_get_store_status_test.go
+++ b/r_get_store_status_test.go
@@ -6,10 +6,12 @@ import (
 
 	"github.com/DEXPRO-Solutions-GmbH/easclient"
 	"github.com/DEXPRO-Solutions-GmbH/easclient/eastest"
+	"github.com/DEXPRO-Solutions-GmbH/easclient/internal"
 	"github.com/stretchr/testify/require"
 )
 
 func TestStoreClient_GetStoreStatus(t *testing.T) {
+	internal.TestPrelude(t)
 	eastest.SkipInCI(t)
 
 	ctx := context.Background()

--- a/r_get_store_status_test.go
+++ b/r_get_store_status_test.go
@@ -16,7 +16,7 @@ func TestStoreClient_GetStoreStatus(t *testing.T) {
 	user := easclient.NewUserClaims("test@dexpro.de")
 	ctx = user.SetOnContext(ctx)
 
-	status, err := DefaultClient.GetStoreStatus(ctx)
+	status, err := eastest.DefaultClient.GetStoreStatus(ctx)
 	require.NoError(t, err)
 	require.NotNil(t, status)
 }

--- a/r_get_store_status_test.go
+++ b/r_get_store_status_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 
 	"github.com/DEXPRO-Solutions-GmbH/easclient"
+	"github.com/DEXPRO-Solutions-GmbH/easclient/eastest"
 	"github.com/stretchr/testify/require"
 )
 
 func TestStoreClient_GetStoreStatus(t *testing.T) {
-	testPrelude(t)
+	eastest.SkipInCI(t)
 
 	ctx := context.Background()
 	user := easclient.NewUserClaims("test@dexpro.de")

--- a/r_put_store_test.go
+++ b/r_put_store_test.go
@@ -18,7 +18,7 @@ func TestStoreClient_PutStore(t *testing.T) {
 
 	storeName := "random-store"
 
-	err := eastest.DefaultServerClient.PutStore(ctx, storeName, &easclient.PutStoreRequest{
+	err := eastest.DefaultServerClient().PutStore(ctx, storeName, &easclient.PutStoreRequest{
 		ConfigurationTemplate: easclient.ConfigurationTemplate{
 			Name: "default",
 			Parameters: []easclient.ConfigurationParameter{

--- a/r_put_store_test.go
+++ b/r_put_store_test.go
@@ -6,10 +6,12 @@ import (
 
 	"github.com/DEXPRO-Solutions-GmbH/easclient"
 	"github.com/DEXPRO-Solutions-GmbH/easclient/eastest"
+	"github.com/DEXPRO-Solutions-GmbH/easclient/internal"
 	"github.com/stretchr/testify/require"
 )
 
 func TestStoreClient_PutStore(t *testing.T) {
+	internal.TestPrelude(t)
 	eastest.SkipInCI(t)
 
 	ctx := context.Background()

--- a/r_put_store_test.go
+++ b/r_put_store_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 
 	"github.com/DEXPRO-Solutions-GmbH/easclient"
+	"github.com/DEXPRO-Solutions-GmbH/easclient/eastest"
 	"github.com/stretchr/testify/require"
 )
 
 func TestStoreClient_PutStore(t *testing.T) {
-	testPrelude(t)
+	eastest.SkipInCI(t)
 
 	ctx := context.Background()
 	user := easclient.NewUserClaims("test@dexpro.de")

--- a/r_put_store_test.go
+++ b/r_put_store_test.go
@@ -18,7 +18,7 @@ func TestStoreClient_PutStore(t *testing.T) {
 
 	storeName := "random-store"
 
-	err := DefaultServerClient.PutStore(ctx, storeName, &easclient.PutStoreRequest{
+	err := eastest.DefaultServerClient.PutStore(ctx, storeName, &easclient.PutStoreRequest{
 		ConfigurationTemplate: easclient.ConfigurationTemplate{
 			Name: "default",
 			Parameters: []easclient.ConfigurationParameter{


### PR DESCRIPTION
This PR introduces a reusable test package which we want to use in another project.

The idea here is to make the `eastest` pkg the one to use, when one is in need of having a test client for the EAS.

The usage of ENV variables is purposefully opinionated: This allows us to have a singe .env file for multiple project, all using the same, local EAS container.

If you, future user, need this to be more configurable, submit a PR 😉 