### PR TITLE
Change Post record response ID from string to uuid.UUID

### DIFF
--- a/r_store_post_record.go
+++ b/r_store_post_record.go
@@ -5,11 +5,13 @@ import (
 	"fmt"
 	"net/http"
 	"strings"
+
+	"github.com/google/uuid"
 )
 
 type PostRecordResponse struct {
 	Records []struct {
-		Id   string `json:"id"`
+		Id   uuid.UUID `json:"id"`
 		Link struct {
 			Type  string `json:"type"`
 			Title string `json:"title"`

--- a/r_store_post_record_test.go
+++ b/r_store_post_record_test.go
@@ -30,7 +30,6 @@ func TestStoreClient_PostRecord(t *testing.T) {
 	require.NotNil(t, res)
 
 	require.Len(t, res.Records, 1)
-	id, err := uuid.Parse(res.Records[0].Id)
 	require.NoError(t, err)
-	require.NotEqual(t, uuid.Nil, id)
+	require.NotEqual(t, uuid.Nil, res.Records[0].Id)
 }


### PR DESCRIPTION
The changed field should have been a UUID from the start, I simply forgot to change the type when generating the struct from a JSON response example.