### PR TITLE
Add support for attachments on StoreClient.PostRecord

### DIFF
--- a/template_record.go
+++ b/template_record.go
@@ -8,7 +8,14 @@ import (
 const recordTemplateStr = `<?xml version="1.0"?>
 <records xmlns="http://namespace.otris.de/2010/09/archive/recordExtern">
     <record>{{range $key, $value := .Fields}}
-		<field name="{{$key}}">{{$value}}</field>{{end}}
+		<field name="{{$key}}">{{$value}}</field>{{end}}{{range $key, $value := .Attachments}}
+		<attachment>
+			<name>{{$value.Name}}</name>
+			<path>{{$value.Path}}</path>
+			<size>{{$value.Size}}</size>
+			<register>{{$value.Register}}</register>
+			<author>{{$value.Author}}</author>
+		</attachment>{{end}}
     </record>
 </records>
 `

--- a/template_record.go
+++ b/template_record.go
@@ -20,14 +20,14 @@ const recordTemplateStr = `<?xml version="1.0"?>
 </records>
 `
 
-var recordTempalte *template.Template
+var recordTemplate *template.Template
 
 func init() {
 	t, err := template.New("putRecord").Parse(recordTemplateStr)
 	if err != nil {
 		panic(err)
 	}
-	recordTempalte = t
+	recordTemplate = t
 }
 
 type RecordRequest struct {
@@ -47,7 +47,7 @@ type RecordRequestAttachment struct {
 
 func renderRecordTemplate(request *RecordRequest) (string, error) {
 	buf := new(bytes.Buffer)
-	err := recordTempalte.Execute(buf, request)
+	err := recordTemplate.Execute(buf, request)
 	if err != nil {
 		return "", err
 	}

--- a/template_record.go
+++ b/template_record.go
@@ -24,7 +24,18 @@ func init() {
 }
 
 type RecordRequest struct {
-	Fields map[string]string
+	Fields      map[string]string
+	Attachments []*RecordRequestAttachment
+}
+
+// RecordRequestAttachment is used in a RecordRequest to specify
+// spooled attachments to be added to the record.
+type RecordRequestAttachment struct {
+	Name     string
+	Path     string
+	Size     uint64
+	Register string
+	Author   string
 }
 
 func renderRecordTemplate(request *RecordRequest) (string, error) {

--- a/template_record_test.go
+++ b/template_record_test.go
@@ -8,16 +8,17 @@ import (
 )
 
 func Test_renderPutRecordTemplate(t *testing.T) {
-	req := &RecordRequest{
-		Fields: map[string]string{
-			"Creditor": "DE123456789",
-			"Debitor":  "DE987654321",
-		},
-	}
+	t.Run("simple record", func(t *testing.T) {
+		req := &RecordRequest{
+			Fields: map[string]string{
+				"Creditor": "DE123456789",
+				"Debitor":  "DE987654321",
+			},
+		}
 
-	xml, err := renderRecordTemplate(req)
-	require.NoError(t, err)
-	expected := `<?xml version="1.0"?>
+		xml, err := renderRecordTemplate(req)
+		require.NoError(t, err)
+		expected := `<?xml version="1.0"?>
 <records xmlns="http://namespace.otris.de/2010/09/archive/recordExtern">
     <record>
 		<field name="Creditor">DE123456789</field>
@@ -25,6 +26,57 @@ func Test_renderPutRecordTemplate(t *testing.T) {
     </record>
 </records>
 `
+		assert.Equal(t, expected, xml)
+	})
 
-	assert.Equal(t, expected, xml)
+	t.Run("record with attachments", func(t *testing.T) {
+		req := &RecordRequest{
+			Fields: map[string]string{
+				"Creditor": "DE123456789",
+				"Debitor":  "DE987654321",
+			},
+			Attachments: []*RecordRequestAttachment{
+				{
+					Name:     "Test.pdf",
+					Path:     "ff0351a7-aa00-4269-ab49-fb4172e3193f.tmp",
+					Size:     56865,
+					Register: "Testregister",
+					Author:   "Test",
+				},
+				{
+					Name:     "Test.pdf",
+					Path:     "ff0351a7-aa00-4269-ab49-fb4172e3193f.tmp",
+					Size:     56865,
+					Register: "",
+					Author:   "",
+				},
+			},
+		}
+
+		xml, err := renderRecordTemplate(req)
+		require.NoError(t, err)
+		expected := `<?xml version="1.0"?>
+<records xmlns="http://namespace.otris.de/2010/09/archive/recordExtern">
+    <record>
+		<field name="Creditor">DE123456789</field>
+		<field name="Debitor">DE987654321</field>
+		<attachment>
+			<name>Test.pdf</name>
+			<path>ff0351a7-aa00-4269-ab49-fb4172e3193f.tmp</path>
+			<size>56865</size>
+			<register>Testregister</register>
+			<author>Test</author>
+		</attachment>
+		<attachment>
+			<name>Test.pdf</name>
+			<path>ff0351a7-aa00-4269-ab49-fb4172e3193f.tmp</path>
+			<size>56865</size>
+			<register></register>
+			<author></author>
+		</attachment>
+    </record>
+</records>
+`
+		assert.Equal(t, expected, xml)
+	})
 }


### PR DESCRIPTION
This will allow users to include attachments they have previously spooled.