### PR TITLE
Remove empty values in attachment XML template to fix unset values

### DIFF
--- a/template_record.go
+++ b/template_record.go
@@ -11,10 +11,10 @@ const recordTemplateStr = `<?xml version="1.0"?>
 		<field name="{{$key}}">{{$value}}</field>{{end}}{{range $key, $value := .Attachments}}
 		<attachment>
 			<name>{{$value.Name}}</name>
-			<path>{{$value.Path}}</path>
-			<size>{{$value.Size}}</size>
-			<register>{{$value.Register}}</register>
-			<author>{{$value.Author}}</author>
+			<path>{{$value.Path}}</path>{{if $value.Size}}
+			<size>{{$value.Size}}</size>{{end}}{{if $value.Register}}
+			<register>{{$value.Register}}</register>{{end}}{{if $value.Author}}
+			<author>{{$value.Author}}</author>{{end}}
 		</attachment>{{end}}
     </record>
 </records>
@@ -37,6 +37,8 @@ type RecordRequest struct {
 
 // RecordRequestAttachment is used in a RecordRequest to specify
 // spooled attachments to be added to the record.
+//
+// The EAS expects at least Name and Path to be set.
 type RecordRequestAttachment struct {
 	Name     string
 	Path     string

--- a/template_record_test.go
+++ b/template_record_test.go
@@ -71,8 +71,37 @@ func Test_renderPutRecordTemplate(t *testing.T) {
 			<name>Test.pdf</name>
 			<path>ff0351a7-aa00-4269-ab49-fb4172e3193f.tmp</path>
 			<size>56865</size>
-			<register></register>
-			<author></author>
+		</attachment>
+    </record>
+</records>
+`
+		assert.Equal(t, expected, xml)
+	})
+
+	t.Run("record with attachment with minimal fields", func(t *testing.T) {
+		req := &RecordRequest{
+			Fields: map[string]string{
+				"Creditor": "DE123456789",
+				"Debitor":  "DE987654321",
+			},
+			Attachments: []*RecordRequestAttachment{
+				{
+					Name: "Test.pdf",
+					Path: "ff0351a7-aa00-4269-ab49-fb4172e3193f.tmp",
+				},
+			},
+		}
+
+		xml, err := renderRecordTemplate(req)
+		require.NoError(t, err)
+		expected := `<?xml version="1.0"?>
+<records xmlns="http://namespace.otris.de/2010/09/archive/recordExtern">
+    <record>
+		<field name="Creditor">DE123456789</field>
+		<field name="Debitor">DE987654321</field>
+		<attachment>
+			<name>Test.pdf</name>
+			<path>ff0351a7-aa00-4269-ab49-fb4172e3193f.tmp</path>
 		</attachment>
     </record>
 </records>


### PR DESCRIPTION
This PR allows client users to not set the `size`, `author` or `register` fields and still have a valid request.