### PR TITLE
Change SearchResult.Title field to string (from bool)

### DIFF
--- a/r_store_search.go
+++ b/r_store_search.go
@@ -70,7 +70,7 @@ type Link struct {
 }
 
 type SearchResult struct {
-	Title            bool         `json:"title"`
+	Title            string       `json:"title"`
 	Score            float64      `json:"score"`
 	Id               uuid.UUID    `json:"id"`
 	FileLink         Link         `json:"fileLink"`


### PR DESCRIPTION
It seems that the initial type we created did not properly match the actual result EAS returns.

Reason for this change is this error:

```
json: cannot unmarshal string into Go struct field SearchResult.result.title of type bool"
```
