### PR TITLE
Remove SearchResult.Title field due to inconsistent API response

### DIFF
--- a/r_store_search.go
+++ b/r_store_search.go
@@ -70,7 +70,8 @@ type Link struct {
 }
 
 type SearchResult struct {
-	Title            string       `json:"title"`
+	// TODO: Re-add this field once we can confirm this is either always string or bool.
+	// Title            string       `json:"title"`
 	Score            float64      `json:"score"`
 	Id               uuid.UUID    `json:"id"`
 	FileLink         Link         `json:"fileLink"`


### PR DESCRIPTION
It seems that the API sometimes responds with a bool, sometimes a string.

Follow up to #24 